### PR TITLE
fix: show live request after sending

### DIFF
--- a/src/components/chat/GoogleSttChat.tsx
+++ b/src/components/chat/GoogleSttChat.tsx
@@ -208,7 +208,7 @@ export const GoogleSttChat = () => {
     if (isWhisperEnabled) {
       await stopRecording();
     }
-    const requestWithoutInitialKeywords = removeInitialKeyword(sanitizeText(interim), wakeKeywords)
+    const requestWithoutInitialKeywords = removeInitialKeyword(sanitizeText(interimsRef.current.join(' ')), wakeKeywords)
     const requestWithoutKeywords = removeTerminatorKeyword(requestWithoutInitialKeywords, terminatorKeywords)
     setOpenaiRequest(requestWithoutKeywords)
 
@@ -233,6 +233,7 @@ export const GoogleSttChat = () => {
       return
     }
     setInterim('');
+    interimsRef.current = [];
     if (isWhisperEnabled) {
       startRecording().then(() => {
         console.log("Whisper start recording")
@@ -259,7 +260,6 @@ export const GoogleSttChat = () => {
         console.log("Whisper stop recording")
       })
     }
-
     setOpenaiRequest(prev => {
       const requestWithoutInitialKeywords = removeInitialKeyword(sanitizeText(`${prev} ${interim}`), wakeKeywords)
       const requestWithoutKeywords = removeTerminatorKeyword(requestWithoutInitialKeywords, terminatorKeywords)
@@ -955,10 +955,11 @@ export const GoogleSttChat = () => {
           ))}
           {((interim && !isLoading && isRecording) || isRequestReadyForTranscription()) ? (
             <ChatMessage
-              message={interim}
+              message={interimsRef.current.length > 1 ? `${interimsRef.current.slice(1, interimsRef.current.length - 1).join(' ')} ${interim}` : interim}
               sender='user'
               loading={true}
-            />) : null}
+            />
+          ) : null}
         </div>
       </div>
       <GoogleSTTPill

--- a/src/components/chat/methods/index.ts
+++ b/src/components/chat/methods/index.ts
@@ -90,7 +90,7 @@ export const trimText = (text: string): string => {
 };
 
 export const removeInitialKeyword = (text: string, wakeWords: string): string => {
-  const lowerCaseText = text.toLowerCase();
+  const lowerCaseText = text.toLocaleLowerCase();
   const wake_words = wakeWords?.split(',') || WAKE_WORDS?.split(',');
   wake_words.forEach((keyword) => {
     const last_keyword_chunk = keyword.split(' ').reverse()[0];


### PR DESCRIPTION
Show a closer text to the final request while the user is speaking before sending it to Openai.