### PR TITLE
fix: avoid send 2 resuqest (written and dictated)

### DIFF
--- a/src/components/chat/GoogleSttChat.tsx
+++ b/src/components/chat/GoogleSttChat.tsx
@@ -1007,7 +1007,7 @@ export const GoogleSttChat = () => {
         onStartListening={startListening}
         onStopListening={stopListening}
         onStopUttering={stopUttering}
-        onSubmitQuery={submitTranscript}
+        onSubmitQuery={!startKeywordDetectedRef.current ? submitTranscript : null}
       />
     </div>
   );


### PR DESCRIPTION
Avoid sending 2 requests: one by written text and another by dictating the request.